### PR TITLE
use login better than name on plain format

### DIFF
--- a/bin/contributors
+++ b/bin/contributors
@@ -134,7 +134,7 @@ function generatePlain(json) {
            + "# https://github.com/xingrz/node-contributors\n\n"
 
   return lead + json.contributors.map(function(i) {
-    return i.name
+    return (i.login || i.name)
          + ' <' + i.email + '>'
          + ' (https://github.com/' + i.login + ')'
   }).join("\n")


### PR DESCRIPTION
```
# Ordered by date of first contribution.
# Auto-generated by 'contributors' on Sun, 19 Jan 2014 12:53:33 GMT.
# https://github.com/xingrz/node-contributors

fengmk2 <fengmk2@gmail.com> (https://github.com/fengmk2)
kof <oleg008@gmail.com> (https://github.com/kof)
```

it's better than 

```
# Ordered by date of first contribution.
# Auto-generated by 'contributors' on Sun, 19 Jan 2014 12:38:57 GMT.
# https://github.com/xingrz/node-contributors

fengmk2 <fengmk2@gmail.com> (https://github.com/fengmk2)
Oleg Slobodskoi <oleg008@gmail.com> (https://github.com/kof)
```

Because AUTHORS will auto add to package.json `contributors` property:

![image](https://f.cloud.github.com/assets/156269/1949468/e6b8b2c6-8108-11e3-99b6-3db52cb11c25.png) 

http://cnpmjs.org/package/charset
